### PR TITLE
Can't recovery from High QPS

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -226,6 +226,7 @@ func (p *MNSQueue) checkQPS() {
 	p.qpsMonitor.Pulse()
 	if p.qpsLimit > 0 {
 		for p.qpsMonitor.QPS() > p.qpsLimit {
+			p.qpsMonitor.Pulse()
 			time.Sleep(time.Millisecond * 10)
 		}
 	}


### PR DESCRIPTION
The origin design can't recover from the high qps, if receiveMessage runs in a single goroutine, because no one has the chance to update the latestIndex.  There is still a problem here, the sleep time need to match the QPS, I didn't cover this case